### PR TITLE
fix: route all MCP tool calls through one dispatcher and open the HTTP client

### DIFF
--- a/src/qdrant_mcp/database/collections.py
+++ b/src/qdrant_mcp/database/collections.py
@@ -2,7 +2,6 @@
 
 from typing import Any
 
-from mcp.server import Server
 from mcp.types import Tool
 
 from .client import QdrantDatabaseClient
@@ -83,17 +82,16 @@ async def collection_exists(client: QdrantDatabaseClient, collection_name: str) 
     return await client.get(f"/collections/{collection_name}/exists")
 
 
-def register_collection_tools(server: Server, client: QdrantDatabaseClient, tools_list: list) -> None:
-    """Register collection management tools with MCP server.
+def register_collection_tools(
+    client: QdrantDatabaseClient, tools_list: list, handlers: dict
+) -> None:
+    """Register collection management tools.
 
     Args:
-        server: MCP server instance
         client: Qdrant database client
         tools_list: List to append tool definitions to
+        handlers: Mapping of tool name -> async handler to populate
     """
-
-    from mcp.types import Tool
-
     # Define tools
     tools_list.append(Tool(
         name="qdrant_db_collections_list",
@@ -149,72 +147,51 @@ def register_collection_tools(server: Server, client: QdrantDatabaseClient, tool
         },
     ))
 
-    @server.call_tool()
     async def qdrant_db_collections_list(arguments: dict[str, Any]) -> list[dict[str, Any]]:
-        """List all collections in the Qdrant database.
-
-        Returns a list of all collections with their configurations.
-        """
+        """List all collections in the Qdrant database."""
         result = await list_collections(client)
         return [{"type": "text", "text": str(result)}]
 
-    @server.call_tool()
     async def qdrant_db_collections_get(arguments: dict[str, Any]) -> list[dict[str, Any]]:
-        """Get detailed information about a specific collection.
-
-        Args:
-            collection_name: Name of the collection to retrieve
-        """
+        """Get detailed information about a specific collection."""
         collection_name = arguments["collection_name"]
         result = await get_collection(client, collection_name)
         return [{"type": "text", "text": str(result)}]
 
-    @server.call_tool()
     async def qdrant_db_collections_create(arguments: dict[str, Any]) -> list[dict[str, Any]]:
-        """Create a new collection with specified configuration.
-
-        Args:
-            collection_name: Name for the new collection
-            vectors: Vector configuration (size, distance metric)
-            Additional optional parameters for collection configuration
-        """
+        """Create a new collection with specified configuration."""
         collection_name = arguments["collection_name"]
         # Remove collection_name from arguments to get config
         config = {k: v for k, v in arguments.items() if k != "collection_name"}
         result = await create_collection(client, collection_name, config)
         return [{"type": "text", "text": str(result)}]
 
-    @server.call_tool()
     async def qdrant_db_collections_delete(arguments: dict[str, Any]) -> list[dict[str, Any]]:
-        """Delete a collection and all its data.
-
-        Args:
-            collection_name: Name of the collection to delete
-        """
+        """Delete a collection and all its data."""
         collection_name = arguments["collection_name"]
         result = await delete_collection(client, collection_name)
         return [{"type": "text", "text": str(result)}]
 
-    @server.call_tool()
     async def qdrant_db_collections_update(arguments: dict[str, Any]) -> list[dict[str, Any]]:
-        """Update collection configuration.
-
-        Args:
-            collection_name: Name of the collection
-            Updates to apply to the collection configuration
-        """
+        """Update collection configuration."""
         collection_name = arguments["collection_name"]
         updates = {k: v for k, v in arguments.items() if k != "collection_name"}
         result = await update_collection(client, collection_name, updates)
         return [{"type": "text", "text": str(result)}]
 
-    @server.call_tool()
     async def qdrant_db_collections_exists(arguments: dict[str, Any]) -> list[dict[str, Any]]:
-        """Check if a collection exists.
-
-        Args:
-            collection_name: Name of the collection to check
-        """
+        """Check if a collection exists."""
         collection_name = arguments["collection_name"]
         result = await collection_exists(client, collection_name)
         return [{"type": "text", "text": str(result)}]
+
+    handlers.update(
+        {
+            "qdrant_db_collections_list": qdrant_db_collections_list,
+            "qdrant_db_collections_get": qdrant_db_collections_get,
+            "qdrant_db_collections_create": qdrant_db_collections_create,
+            "qdrant_db_collections_delete": qdrant_db_collections_delete,
+            "qdrant_db_collections_update": qdrant_db_collections_update,
+            "qdrant_db_collections_exists": qdrant_db_collections_exists,
+        }
+    )

--- a/src/qdrant_mcp/database/health.py
+++ b/src/qdrant_mcp/database/health.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from mcp.server import Server
+from mcp.types import Tool
 
 from .client import QdrantDatabaseClient
 
@@ -60,16 +60,14 @@ async def metrics(client: QdrantDatabaseClient) -> str:
     return response.text
 
 
-def register_health_tools(server: Server, client: QdrantDatabaseClient, tools_list: list) -> None:
-    """Register health check tools with MCP server.
+def register_health_tools(client: QdrantDatabaseClient, tools_list: list, handlers: dict) -> None:
+    """Register health check tools.
 
     Args:
-        server: MCP server instance
         client: Qdrant database client
         tools_list: List to append tool definitions to
+        handlers: Mapping of tool name -> async handler to populate
     """
-    from mcp.types import Tool
-
     # Define tools
     tools_list.extend([
         Tool(
@@ -99,47 +97,37 @@ def register_health_tools(server: Server, client: QdrantDatabaseClient, tools_li
         ),
     ])
 
-    @server.call_tool()
     async def qdrant_db_health_root(arguments: dict[str, Any]) -> list[dict[str, Any]]:
-        """Get Qdrant version and build information.
-
-        Returns version, title, and build information.
-        """
+        """Get Qdrant version and build information."""
         result = await get_root(client)
         return [{"type": "text", "text": str(result)}]
 
-    @server.call_tool()
     async def qdrant_db_health_check(arguments: dict[str, Any]) -> list[dict[str, Any]]:
-        """Perform health check on Qdrant database.
-
-        Returns health status of the database.
-        """
+        """Perform health check on Qdrant database."""
         result = await healthz(client)
         return [{"type": "text", "text": str(result)}]
 
-    @server.call_tool()
     async def qdrant_db_health_liveness(arguments: dict[str, Any]) -> list[dict[str, Any]]:
-        """Check if Qdrant service is running.
-
-        Liveness probe for Kubernetes-style health checks.
-        """
+        """Check if Qdrant service is running."""
         result = await livez(client)
         return [{"type": "text", "text": str(result)}]
 
-    @server.call_tool()
     async def qdrant_db_health_readiness(arguments: dict[str, Any]) -> list[dict[str, Any]]:
-        """Check if Qdrant service is ready to serve requests.
-
-        Readiness probe for Kubernetes-style health checks.
-        """
+        """Check if Qdrant service is ready to serve requests."""
         result = await readyz(client)
         return [{"type": "text", "text": str(result)}]
 
-    @server.call_tool()
     async def qdrant_db_health_metrics(arguments: dict[str, Any]) -> list[dict[str, Any]]:
-        """Get Prometheus metrics from Qdrant.
-
-        Returns metrics in Prometheus text format.
-        """
+        """Get Prometheus metrics from Qdrant."""
         result = await metrics(client)
         return [{"type": "text", "text": result}]
+
+    handlers.update(
+        {
+            "qdrant_db_health_root": qdrant_db_health_root,
+            "qdrant_db_health_check": qdrant_db_health_check,
+            "qdrant_db_health_liveness": qdrant_db_health_liveness,
+            "qdrant_db_health_readiness": qdrant_db_health_readiness,
+            "qdrant_db_health_metrics": qdrant_db_health_metrics,
+        }
+    )

--- a/src/qdrant_mcp/database/index.py
+++ b/src/qdrant_mcp/database/index.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from mcp.server import Server
+from mcp.types import Tool
 
 from .client import QdrantDatabaseClient
 
@@ -44,16 +44,14 @@ async def delete_field_index(
     return await client.delete(f"/collections/{collection_name}/index/{field_name}")
 
 
-def register_index_tools(server: Server, client: QdrantDatabaseClient, tools_list: list) -> None:
-    """Register index management tools with MCP server.
+def register_index_tools(client: QdrantDatabaseClient, tools_list: list, handlers: dict) -> None:
+    """Register index management tools.
 
     Args:
-        server: MCP server instance
         client: Qdrant database client
         tools_list: List to append tool definitions to
+        handlers: Mapping of tool name -> async handler to populate
     """
-    from mcp.types import Tool
-
     # Define tools
     tools_list.extend([
         Tool(
@@ -83,17 +81,8 @@ def register_index_tools(server: Server, client: QdrantDatabaseClient, tools_lis
         ),
     ])
 
-    @server.call_tool()
     async def qdrant_db_index_create(arguments: dict[str, Any]) -> list[dict[str, Any]]:
-        """Create an index for a payload field.
-
-        Creates an index to speed up filtering operations on a specific field.
-
-        Args:
-            collection_name: Name of the collection
-            field_name: Name of the field to index
-            field_schema: Optional field schema configuration
-        """
+        """Create an index for a payload field."""
         result = await create_field_index(
             client,
             arguments["collection_name"],
@@ -102,17 +91,16 @@ def register_index_tools(server: Server, client: QdrantDatabaseClient, tools_lis
         )
         return [{"type": "text", "text": str(result)}]
 
-    @server.call_tool()
     async def qdrant_db_index_delete(arguments: dict[str, Any]) -> list[dict[str, Any]]:
-        """Delete an index for a payload field.
-
-        Removes the index from a field. Filtering on this field will be slower.
-
-        Args:
-            collection_name: Name of the collection
-            field_name: Name of the field to remove index from
-        """
+        """Delete an index for a payload field."""
         result = await delete_field_index(
             client, arguments["collection_name"], arguments["field_name"]
         )
         return [{"type": "text", "text": str(result)}]
+
+    handlers.update(
+        {
+            "qdrant_db_index_create": qdrant_db_index_create,
+            "qdrant_db_index_delete": qdrant_db_index_delete,
+        }
+    )

--- a/src/qdrant_mcp/database/payload.py
+++ b/src/qdrant_mcp/database/payload.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from mcp.server import Server
+from mcp.types import Tool
 
 from .client import QdrantDatabaseClient
 
@@ -90,16 +90,14 @@ async def clear_payload(
     )
 
 
-def register_payload_tools(server: Server, client: QdrantDatabaseClient, tools_list: list) -> None:
-    """Register payload management tools with MCP server.
+def register_payload_tools(client: QdrantDatabaseClient, tools_list: list, handlers: dict) -> None:
+    """Register payload management tools.
 
     Args:
-        server: MCP server instance
         client: Qdrant database client
         tools_list: List to append tool definitions to
+        handlers: Mapping of tool name -> async handler to populate
     """
-    from mcp.types import Tool
-
     # Define tools
     tools_list.extend([
         Tool(
@@ -155,15 +153,8 @@ def register_payload_tools(server: Server, client: QdrantDatabaseClient, tools_l
         ),
     ])
 
-    @server.call_tool()
     async def qdrant_db_payload_set(arguments: dict[str, Any]) -> list[dict[str, Any]]:
-        """Set payload for specified points (merges with existing payload).
-
-        Args:
-            collection_name: Name of the collection
-            payload: Payload data to set
-            points: List of point IDs to update
-        """
+        """Set payload for specified points (merges with existing payload)."""
         result = await set_payload(
             client,
             arguments["collection_name"],
@@ -172,15 +163,8 @@ def register_payload_tools(server: Server, client: QdrantDatabaseClient, tools_l
         )
         return [{"type": "text", "text": str(result)}]
 
-    @server.call_tool()
     async def qdrant_db_payload_overwrite(arguments: dict[str, Any]) -> list[dict[str, Any]]:
-        """Overwrite payload for specified points (replaces existing payload).
-
-        Args:
-            collection_name: Name of the collection
-            payload: Payload data to set
-            points: List of point IDs to update
-        """
+        """Overwrite payload for specified points (replaces existing payload)."""
         result = await overwrite_payload(
             client,
             arguments["collection_name"],
@@ -189,15 +173,8 @@ def register_payload_tools(server: Server, client: QdrantDatabaseClient, tools_l
         )
         return [{"type": "text", "text": str(result)}]
 
-    @server.call_tool()
     async def qdrant_db_payload_delete(arguments: dict[str, Any]) -> list[dict[str, Any]]:
-        """Delete specific payload fields from points.
-
-        Args:
-            collection_name: Name of the collection
-            keys: List of payload keys to delete
-            points: List of point IDs to update
-        """
+        """Delete specific payload fields from points."""
         result = await delete_payload(
             client,
             arguments["collection_name"],
@@ -206,15 +183,18 @@ def register_payload_tools(server: Server, client: QdrantDatabaseClient, tools_l
         )
         return [{"type": "text", "text": str(result)}]
 
-    @server.call_tool()
     async def qdrant_db_payload_clear(arguments: dict[str, Any]) -> list[dict[str, Any]]:
-        """Clear all payload data from specified points.
-
-        Args:
-            collection_name: Name of the collection
-            points: List of point IDs to clear
-        """
+        """Clear all payload data from specified points."""
         result = await clear_payload(
             client, arguments["collection_name"], arguments["points"]
         )
         return [{"type": "text", "text": str(result)}]
+
+    handlers.update(
+        {
+            "qdrant_db_payload_set": qdrant_db_payload_set,
+            "qdrant_db_payload_overwrite": qdrant_db_payload_overwrite,
+            "qdrant_db_payload_delete": qdrant_db_payload_delete,
+            "qdrant_db_payload_clear": qdrant_db_payload_clear,
+        }
+    )

--- a/src/qdrant_mcp/database/points.py
+++ b/src/qdrant_mcp/database/points.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from mcp.server import Server
+from mcp.types import Tool
 
 from .client import QdrantDatabaseClient
 
@@ -130,16 +130,14 @@ async def batch_update(
     )
 
 
-def register_point_tools(server: Server, client: QdrantDatabaseClient, tools_list: list) -> None:
-    """Register point management tools with MCP server.
+def register_point_tools(client: QdrantDatabaseClient, tools_list: list, handlers: dict) -> None:
+    """Register point management tools.
 
     Args:
-        server: MCP server instance
         client: Qdrant database client
         tools_list: List to append tool definitions to
+        handlers: Mapping of tool name -> async handler to populate
     """
-    from mcp.types import Tool
-
     # Define tools
     tools_list.extend([
         Tool(
@@ -230,74 +228,36 @@ def register_point_tools(server: Server, client: QdrantDatabaseClient, tools_lis
         ),
     ])
 
-    @server.call_tool()
     async def qdrant_db_points_upsert(arguments: dict[str, Any]) -> list[dict[str, Any]]:
-        """Upsert (insert or update) points in a collection.
-
-        Args:
-            collection_name: Name of the collection
-            points: List of points with id, vector, and optional payload
-        """
+        """Upsert (insert or update) points in a collection."""
         result = await upsert_points(
             client, arguments["collection_name"], arguments["points"]
         )
         return [{"type": "text", "text": str(result)}]
 
-    @server.call_tool()
     async def qdrant_db_points_get(arguments: dict[str, Any]) -> list[dict[str, Any]]:
-        """Retrieve multiple points by their IDs.
-
-        Args:
-            collection_name: Name of the collection
-            ids: List of point IDs to retrieve
-        """
+        """Retrieve multiple points by their IDs."""
         result = await get_points(client, arguments["collection_name"], arguments["ids"])
         return [{"type": "text", "text": str(result)}]
 
-    @server.call_tool()
     async def qdrant_db_points_get_single(arguments: dict[str, Any]) -> list[dict[str, Any]]:
-        """Retrieve a single point by ID.
-
-        Args:
-            collection_name: Name of the collection
-            point_id: ID of the point to retrieve
-        """
+        """Retrieve a single point by ID."""
         result = await get_point(client, arguments["collection_name"], arguments["point_id"])
         return [{"type": "text", "text": str(result)}]
 
-    @server.call_tool()
     async def qdrant_db_points_delete(arguments: dict[str, Any]) -> list[dict[str, Any]]:
-        """Delete points from a collection.
-
-        Args:
-            collection_name: Name of the collection
-            points: List of point IDs to delete
-        """
+        """Delete points from a collection."""
         result = await delete_points(client, arguments["collection_name"], arguments["points"])
         return [{"type": "text", "text": str(result)}]
 
-    @server.call_tool()
     async def qdrant_db_points_count(arguments: dict[str, Any]) -> list[dict[str, Any]]:
-        """Count points in a collection with optional filter.
-
-        Args:
-            collection_name: Name of the collection
-            filter: Optional filter conditions
-        """
+        """Count points in a collection with optional filter."""
         filter_ = arguments.get("filter")
         result = await count_points(client, arguments["collection_name"], filter_)
         return [{"type": "text", "text": str(result)}]
 
-    @server.call_tool()
     async def qdrant_db_points_scroll(arguments: dict[str, Any]) -> list[dict[str, Any]]:
-        """Scroll through points in a collection.
-
-        Args:
-            collection_name: Name of the collection
-            limit: Maximum number of points to return (default: 10)
-            offset: Scroll offset (optional)
-            filter: Optional filter conditions
-        """
+        """Scroll through points in a collection."""
         result = await scroll_points(
             client,
             arguments["collection_name"],
@@ -307,18 +267,21 @@ def register_point_tools(server: Server, client: QdrantDatabaseClient, tools_lis
         )
         return [{"type": "text", "text": str(result)}]
 
-    @server.call_tool()
     async def qdrant_db_points_batch(arguments: dict[str, Any]) -> list[dict[str, Any]]:
-        """Perform multiple update operations in a single batch request.
-
-        Allows you to combine multiple operations (upsert, delete, set_payload, etc.)
-        into a single atomic request for better performance.
-
-        Args:
-            collection_name: Name of the collection
-            operations: List of operations to perform
-        """
+        """Perform multiple update operations in a single batch request."""
         result = await batch_update(
             client, arguments["collection_name"], arguments["operations"]
         )
         return [{"type": "text", "text": str(result)}]
+
+    handlers.update(
+        {
+            "qdrant_db_points_upsert": qdrant_db_points_upsert,
+            "qdrant_db_points_get": qdrant_db_points_get,
+            "qdrant_db_points_get_single": qdrant_db_points_get_single,
+            "qdrant_db_points_delete": qdrant_db_points_delete,
+            "qdrant_db_points_count": qdrant_db_points_count,
+            "qdrant_db_points_scroll": qdrant_db_points_scroll,
+            "qdrant_db_points_batch": qdrant_db_points_batch,
+        }
+    )

--- a/src/qdrant_mcp/database/search.py
+++ b/src/qdrant_mcp/database/search.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from mcp.server import Server
+from mcp.types import Tool
 
 from .client import QdrantDatabaseClient
 
@@ -102,16 +102,14 @@ async def recommend_batch_points(
     )
 
 
-def register_search_tools(server: Server, client: QdrantDatabaseClient, tools_list: list) -> None:
-    """Register vector search tools with MCP server.
+def register_search_tools(client: QdrantDatabaseClient, tools_list: list, handlers: dict) -> None:
+    """Register vector search tools.
 
     Args:
-        server: MCP server instance
         client: Qdrant database client
         tools_list: List to append tool definitions to
+        handlers: Mapping of tool name -> async handler to populate
     """
-    from mcp.types import Tool
-
     # Define tools
     tools_list.extend([
         Tool(
@@ -171,18 +169,8 @@ def register_search_tools(server: Server, client: QdrantDatabaseClient, tools_li
         ),
     ])
 
-    @server.call_tool()
     async def qdrant_db_points_search(arguments: dict[str, Any]) -> list[dict[str, Any]]:
-        """Search for similar vectors in a collection.
-
-        Args:
-            collection_name: Name of the collection
-            vector: Query vector (list of floats)
-            limit: Maximum number of results (default: 10)
-            filter: Optional filter conditions
-            with_payload: Include payload in results (default: true)
-            with_vector: Include vectors in results (default: false)
-        """
+        """Search for similar vectors in a collection."""
         result = await search_points(
             client,
             arguments["collection_name"],
@@ -194,30 +182,15 @@ def register_search_tools(server: Server, client: QdrantDatabaseClient, tools_li
         )
         return [{"type": "text", "text": str(result)}]
 
-    @server.call_tool()
     async def qdrant_db_points_search_batch(arguments: dict[str, Any]) -> list[dict[str, Any]]:
-        """Perform multiple search queries in a single request.
-
-        Args:
-            collection_name: Name of the collection
-            searches: List of search queries
-        """
+        """Perform multiple search queries in a single request."""
         result = await search_batch_points(
             client, arguments["collection_name"], arguments["searches"]
         )
         return [{"type": "text", "text": str(result)}]
 
-    @server.call_tool()
     async def qdrant_db_points_recommend(arguments: dict[str, Any]) -> list[dict[str, Any]]:
-        """Get recommendations based on positive and negative examples.
-
-        Args:
-            collection_name: Name of the collection
-            positive: List of positive example point IDs
-            negative: List of negative example point IDs (optional)
-            limit: Maximum number of results (default: 10)
-            filter: Optional filter conditions
-        """
+        """Get recommendations based on positive and negative examples."""
         result = await recommend_points(
             client,
             arguments["collection_name"],
@@ -228,15 +201,18 @@ def register_search_tools(server: Server, client: QdrantDatabaseClient, tools_li
         )
         return [{"type": "text", "text": str(result)}]
 
-    @server.call_tool()
     async def qdrant_db_points_recommend_batch(arguments: dict[str, Any]) -> list[dict[str, Any]]:
-        """Perform multiple recommendation queries in a single request.
-
-        Args:
-            collection_name: Name of the collection
-            searches: List of recommendation queries
-        """
+        """Perform multiple recommendation queries in a single request."""
         result = await recommend_batch_points(
             client, arguments["collection_name"], arguments["searches"]
         )
         return [{"type": "text", "text": str(result)}]
+
+    handlers.update(
+        {
+            "qdrant_db_points_search": qdrant_db_points_search,
+            "qdrant_db_points_search_batch": qdrant_db_points_search_batch,
+            "qdrant_db_points_recommend": qdrant_db_points_recommend,
+            "qdrant_db_points_recommend_batch": qdrant_db_points_recommend_batch,
+        }
+    )

--- a/src/qdrant_mcp/database/vectors.py
+++ b/src/qdrant_mcp/database/vectors.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from mcp.server import Server
+from mcp.types import Tool
 
 from .client import QdrantDatabaseClient
 
@@ -48,16 +48,14 @@ async def delete_vectors(
     return await client.post(f"/collections/{collection_name}/points/vectors/delete", json=body)
 
 
-def register_vector_tools(server: Server, client: QdrantDatabaseClient, tools_list: list) -> None:
-    """Register vector operation tools with MCP server.
+def register_vector_tools(client: QdrantDatabaseClient, tools_list: list, handlers: dict) -> None:
+    """Register vector operation tools.
 
     Args:
-        server: MCP server instance
         client: Qdrant database client
         tools_list: List to append tool definitions to
+        handlers: Mapping of tool name -> async handler to populate
     """
-    from mcp.types import Tool
-
     # Define tools
     tools_list.extend([
         Tool(
@@ -87,28 +85,15 @@ def register_vector_tools(server: Server, client: QdrantDatabaseClient, tools_li
         ),
     ])
 
-    @server.call_tool()
     async def qdrant_db_vectors_update(arguments: dict[str, Any]) -> list[dict[str, Any]]:
-        """Update vectors for existing points.
-
-        Args:
-            collection_name: Name of the collection
-            points: List of points with id and vector fields
-        """
+        """Update vectors for existing points."""
         result = await update_vectors(
             client, arguments["collection_name"], arguments["points"]
         )
         return [{"type": "text", "text": str(result)}]
 
-    @server.call_tool()
     async def qdrant_db_vectors_delete(arguments: dict[str, Any]) -> list[dict[str, Any]]:
-        """Delete vectors from points.
-
-        Args:
-            collection_name: Name of the collection
-            points: List of point IDs to delete vectors from
-            vector_names: Optional list of vector names (for named vectors)
-        """
+        """Delete vectors from points."""
         result = await delete_vectors(
             client,
             arguments["collection_name"],
@@ -116,3 +101,10 @@ def register_vector_tools(server: Server, client: QdrantDatabaseClient, tools_li
             arguments.get("vector_names"),
         )
         return [{"type": "text", "text": str(result)}]
+
+    handlers.update(
+        {
+            "qdrant_db_vectors_update": qdrant_db_vectors_update,
+            "qdrant_db_vectors_delete": qdrant_db_vectors_delete,
+        }
+    )

--- a/src/qdrant_mcp/server.py
+++ b/src/qdrant_mcp/server.py
@@ -2,11 +2,12 @@
 
 import asyncio
 import logging
-from typing import Any
+from contextlib import AsyncExitStack
+from typing import Any, Awaitable, Callable
 
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
-from mcp.types import Tool
+from mcp.types import TextContent, Tool
 
 from .config import QdrantConfig
 from .database import (
@@ -22,8 +23,14 @@ from .database import (
 
 logger = logging.getLogger(__name__)
 
-# Global list to track registered tools
+# Tool definitions advertised via list_tools().
 REGISTERED_TOOLS: list[Tool] = []
+
+# Maps a tool name to the async handler that executes it. The MCP SDK supports
+# exactly ONE @server.call_tool() handler, so every tool is dispatched through
+# the single handler below using this table.
+ToolHandler = Callable[[dict[str, Any]], Awaitable[list[dict[str, Any]]]]
+TOOL_HANDLERS: dict[str, ToolHandler] = {}
 
 
 async def main() -> None:
@@ -40,29 +47,44 @@ async def main() -> None:
         """List all available tools."""
         return REGISTERED_TOOLS
 
-    # Register database tools if configured
-    if config.validate_database_config():
-        logger.info("Initializing Qdrant Database API tools")
-        db_client = QdrantDatabaseClient(
-            base_url=config.url,  # type: ignore
-            api_key=config.api_key,  # type: ignore
-        )
+    # Single dispatch handler. The SDK invokes this with (name, arguments) for
+    # every tool call; we route to the matching handler in TOOL_HANDLERS.
+    @server.call_tool()
+    async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
+        """Dispatch a tool call to its registered handler."""
+        handler = TOOL_HANDLERS.get(name)
+        if handler is None:
+            raise ValueError(f"Unknown tool: {name}")
+        results = await handler(arguments or {})
+        return [TextContent(type="text", text=item["text"]) for item in results]
 
-        register_collection_tools(server, db_client, REGISTERED_TOOLS)
-        register_point_tools(server, db_client, REGISTERED_TOOLS)
-        register_search_tools(server, db_client, REGISTERED_TOOLS)
-        register_payload_tools(server, db_client, REGISTERED_TOOLS)
-        register_health_tools(server, db_client, REGISTERED_TOOLS)
-        register_vector_tools(server, db_client, REGISTERED_TOOLS)
-        register_index_tools(server, db_client, REGISTERED_TOOLS)
-        logger.info("Registered 30 database tools (Phase 1 complete)")
-    else:
-        logger.warning("Database API not configured. Set QDRANT_URL and QDRANT_API_KEY")
-        logger.info("Running with no tools registered")
+    async with AsyncExitStack() as stack:
+        # Register database tools if configured
+        if config.validate_database_config():
+            logger.info("Initializing Qdrant Database API tools")
+            db_client = QdrantDatabaseClient(
+                base_url=config.url,  # type: ignore[arg-type]
+                api_key=config.api_key or "",
+            )
+            # Open the HTTP client for the lifetime of the server so handlers
+            # can issue requests (otherwise client.client raises RuntimeError).
+            await stack.enter_async_context(db_client)
 
-    # Run server
-    async with stdio_server() as (read_stream, write_stream):
-        await server.run(read_stream, write_stream, server.create_initialization_options())
+            register_collection_tools(db_client, REGISTERED_TOOLS, TOOL_HANDLERS)
+            register_point_tools(db_client, REGISTERED_TOOLS, TOOL_HANDLERS)
+            register_search_tools(db_client, REGISTERED_TOOLS, TOOL_HANDLERS)
+            register_payload_tools(db_client, REGISTERED_TOOLS, TOOL_HANDLERS)
+            register_health_tools(db_client, REGISTERED_TOOLS, TOOL_HANDLERS)
+            register_vector_tools(db_client, REGISTERED_TOOLS, TOOL_HANDLERS)
+            register_index_tools(db_client, REGISTERED_TOOLS, TOOL_HANDLERS)
+            logger.info("Registered %d database tools (Phase 1 complete)", len(REGISTERED_TOOLS))
+        else:
+            logger.warning("Database API not configured. Set QDRANT_URL and QDRANT_API_KEY")
+            logger.info("Running with no tools registered")
+
+        # Run server
+        async with stdio_server() as (read_stream, write_stream):
+            await server.run(read_stream, write_stream, server.create_initialization_options())
 
 
 def serve() -> None:


### PR DESCRIPTION
## Summary

Two bugs prevented **every** database tool from working when running against a current `mcp` SDK (tested with `mcp 1.27.2`). This PR fixes both with no change to tool names or behavior — all 30 Phase 1 tools are preserved.

## Bug 1 — broken tool dispatch

The MCP SDK supports exactly **one** `@server.call_tool()` handler, but each tool registered its own (~30 calls across `database/*.py`). Only the **last** registration (`qdrant_db_index_delete`) survived, and it then received *every* tool call — with a 1-arg `(arguments)` signature while the SDK invokes the handler with **two** args `(name, arguments)`.

Result: every tool call failed with
```
qdrant_db_index_delete() takes 1 positional argument but 2 were given
```
(which is why the error always named `index_delete` no matter which tool was called).

## Bug 2 — uninitialized HTTP client

`QdrantDatabaseClient` was constructed but never entered as an async context, so `QdrantDatabaseClient.client` raised `RuntimeError("Client not initialized. Use 'async with' context manager.")` on every request. Even with dispatch fixed, no tool could reach Qdrant.

## Changes

- **`server.py`**
  - Add a single `@server.call_tool()` dispatcher that routes by tool name through a shared `TOOL_HANDLERS` table.
  - Open the client for the server's lifetime via `AsyncExitStack` so handlers can issue requests.
  - Coerce handler output to `mcp.types.TextContent`.
- **`database/*.py`**
  - `register_*_tools(...)` now populate a shared `{name: handler}` dict (mirroring the existing `tools_list` pattern) instead of each calling `@server.call_tool()`.
  - Drop the now-unused `server` parameter and `from mcp.server import Server` import.

Net: **+172 / −286** across 8 files.

## Verification

Validated end-to-end against a local Qdrant (`qdrant 1.18.2`, native macOS binary) with a fully local agent stack — a local MLX model (Qwen3.5-4B) driven by OpenCode:

- `qdrant_db_collections_list` and `qdrant_db_health_root` return real data through the dispatcher.
- The agent successfully invokes `qdrant_db_collections_list`; the request appears in the Qdrant access log:
  ```
  "GET /collections HTTP/1.1" 200 ... python-httpx/0.28.1
  ```
- All 30 advertised tools have a matching handler (asserted in a smoke test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)